### PR TITLE
Sre6 parknride

### DIFF
--- a/main.c
+++ b/main.c
@@ -200,7 +200,7 @@ void main(void)
     //----------------------------------------------------------------------------
     ReadyToDriveSound *rtds = RTDS_new();
     //BatteryManagementSystem* bms = BMS_new();
-    MotorController *mcm0 = MotorController_new(serialMan, 0xA0, FORWARD, 1000, 5, 15); //CAN addr, direction, torque limit x10 (100 = 10Nm)
+    MotorController *mcm0 = MotorController_new(serialMan, 0xA0, FORWARD, 2300, 5, 15); //CAN addr, direction, torque limit x10 (100 = 10Nm)
     TorqueEncoder *tps = TorqueEncoder_new(bench);
     BrakePressureSensor *bps = BrakePressureSensor_new();
     WheelSpeeds *wss = WheelSpeeds_new(18, 18, 16, 16);

--- a/motorController.c
+++ b/motorController.c
@@ -389,7 +389,7 @@ void MCM_inverterControl(MotorController* me, TorqueEncoder* tps, BrakePressureS
         {
             RTDPercent = 1; //Doesn't matter if button is no longer pressed - RTD light should be on if car is driveable
             SerialManager_send(me->serialMan, "Inverter has been enabled.  Starting RTDS.  Car is ready to drive.\n");
-            RTDS_setVolume(rtds, .005, 1500000);
+            RTDS_setVolume(rtds, .1, 1500000);
             MCM_setStartupStage(me, 4); //MCM_getStartupStage(me) + 1);  //leave this stage since we've already kicked off the RTDS
         }
         break;

--- a/torqueEncoder.c
+++ b/torqueEncoder.c
@@ -42,13 +42,6 @@ TorqueEncoder* TorqueEncoder_new(bool benchMode)
     me->tps1->specMin = 5000 * .55 - 5000 * .006;
     me->tps1->specMax = 5000 * .95 + 5000 * .006;
 
-    //Default calibration values
-    //SRE-3 sensor
-    me->tps0_calibMin = 850;  //me->tps0->sensorValue;
-    me->tps0_calibMax = 1650;  //me->tps0->sensorValue;
-    me->tps1_calibMin = 3270;  //me->tps1->sensorValue;
-    me->tps1_calibMax = 4300;  //me->tps1->sensorValue;
-
     me->calibrated = FALSE;
 
     return me;
@@ -99,7 +92,6 @@ void TorqueEncoder_resetCalibration(TorqueEncoder* me)
 {
     me->calibrated = FALSE;
     
-    //Normal
     me->tps0_calibMin = me->tps0->sensorValue;
     me->tps0_calibMax = me->tps0->sensorValue;
     me->tps1_calibMin = me->tps1->sensorValue;


### PR DESCRIPTION
Resolves #95 - increases BPS deadzone and removes default/invalid/unused calibration values from BPS and TPS
May resolve #105 - brake light stays on / flickering - validation needed