### PR TITLE
Reserving 0x50C for Future Launch Control Messages. Moved DRS & SAS t…

### DIFF
--- a/dev/canManager.c
+++ b/dev/canManager.c
@@ -745,17 +745,17 @@ void canOutput_sendDebugMessage(CanManager* me, TorqueEncoder* tps, BrakePressur
     canMessages[canMessageCount - 1].data[byteNum++] = Sensor_LCButton.sensorValue;
     canMessages[canMessageCount - 1].length = byteNum;
 
-    //50C: SAS (Steering Angle Sensor) and DRS
+    //50C: Launch Control Additional Information
     canMessageCount++;
     byteNum = 0;
     canMessages[canMessageCount - 1].id = canMessageID + canMessageCount - 1;
     canMessages[canMessageCount - 1].id_format = IO_CAN_STD_FRAME;
-    canMessages[canMessageCount - 1].data[byteNum++] = steering_degrees();
-    canMessages[canMessageCount - 1].data[byteNum++] = steering_degrees() >> 8;
-    canMessages[canMessageCount - 1].data[byteNum++] = drs->buttonPressed;
-    canMessages[canMessageCount - 1].data[byteNum++] = drs->currentDRSMode;
-    canMessages[canMessageCount - 1].data[byteNum++] = drs->drsFlapOpen;
-    canMessages[canMessageCount - 1].data[byteNum++] = drs->AutoDRSActive;
+    canMessages[canMessageCount - 1].data[byteNum++] = 0;
+    canMessages[canMessageCount - 1].data[byteNum++] = 0;
+    canMessages[canMessageCount - 1].data[byteNum++] = 0;
+    canMessages[canMessageCount - 1].data[byteNum++] = 0;
+    canMessages[canMessageCount - 1].data[byteNum++] = 0;
+    canMessages[canMessageCount - 1].data[byteNum++] = 0;
     canMessages[canMessageCount - 1].data[byteNum++] = 0;
     canMessages[canMessageCount - 1].data[byteNum++] = 0;
     canMessages[canMessageCount - 1].length = byteNum;
@@ -834,6 +834,21 @@ void canOutput_sendDebugMessage(CanManager* me, TorqueEncoder* tps, BrakePressur
     canMessages[canMessageCount - 1].data[byteNum++] = MCM_commands_getTorqueLimit(mcm) >> 8;
     canMessages[canMessageCount - 1].length = byteNum;
     
+    //515: SAS (Steering Angle Sensor) and DRS
+    canMessageCount++;
+    byteNum = 0;
+    canMessages[canMessageCount - 1].id = canMessageID + canMessageCount - 1;
+    canMessages[canMessageCount - 1].id_format = 0x515;
+    canMessages[canMessageCount - 1].data[byteNum++] = steering_degrees();
+    canMessages[canMessageCount - 1].data[byteNum++] = steering_degrees() >> 8;
+    canMessages[canMessageCount - 1].data[byteNum++] = drs->buttonPressed;
+    canMessages[canMessageCount - 1].data[byteNum++] = drs->currentDRSMode;
+    canMessages[canMessageCount - 1].data[byteNum++] = drs->drsFlapOpen;
+    canMessages[canMessageCount - 1].data[byteNum++] = drs->AutoDRSActive;
+    canMessages[canMessageCount - 1].data[byteNum++] = 0;
+    canMessages[canMessageCount - 1].data[byteNum++] = 0;
+    canMessages[canMessageCount - 1].length = byteNum;
+
     CanManager_send(me, CAN0_HIPRI, canMessages, canMessageCount); 
 
     


### PR DESCRIPTION
…o 0x515, to not conflict with existing powerlimiting CAN messages on their development branches.